### PR TITLE
Nouvelle UX panneau sur fond carton

### DIFF
--- a/public/create.html
+++ b/public/create.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Créer un panneau</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Permanent+Marker&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Permanent Marker', cursive;
+            background: #eee;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            margin: 0;
+            padding: 20px;
+        }
+        #cardboard {
+            width: 400px;
+            height: 200px;
+            background: url('https://www.keeptruckeegreen.org/wp-content/uploads/2020/09/47.png') center/cover;
+            border: 8px solid #333;
+            margin-top: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+        #cardboard span {
+            font-size: 48px;
+            color: #000;
+            word-break: break-word;
+            text-align: center;
+        }
+        input[type="text"] {
+            margin-top: 20px;
+            font-size: 24px;
+            width: 90%;
+            padding: 10px;
+        }
+        button {
+            margin-top: 10px;
+            font-size: 24px;
+            padding: 10px 20px;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <h1>Créer un panneau</h1>
+    <div id="cardboard"><span id="preview"></span></div>
+    <input type="text" id="text" maxlength="15" placeholder="Votre message">
+    <button id="save">Enregistrer</button>
+    <script>
+        const textInput = document.getElementById('text');
+        const preview = document.getElementById('preview');
+        textInput.addEventListener('input', () => {
+            preview.textContent = textInput.value.toUpperCase();
+        });
+        document.getElementById('save').addEventListener('click', async () => {
+            const text = textInput.value.trim();
+            if (!text) return;
+            await fetch('/signs', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text })
+            });
+            window.location.href = '/';
+        });
+    </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <title>Panneaux Fun</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Indie+Flower&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Indie+Flower&family=Permanent+Marker&display=swap" rel="stylesheet">
     <style>
         body {
             font-family: 'Indie Flower', cursive;
@@ -24,12 +24,6 @@
         #create-form {
             margin-bottom: 20px;
         }
-        #sign-text {
-            padding: 10px;
-            font-size: 16px;
-            border-radius: 4px;
-            border: none;
-        }
         button {
             padding: 10px 20px;
             font-size: 16px;
@@ -47,19 +41,21 @@
         .sign {
             position: relative;
             width: 200px;
-            height: 200px;
-            background-color: #fff;
+            height: 150px;
+            background: url('https://www.keeptruckeegreen.org/wp-content/uploads/2020/09/47.png') center/cover;
             color: #000;
-            font-size: 48px;
+            font-family: 'Permanent Marker', cursive;
+            font-size: 40px;
             font-weight: bold;
             border: 4px solid #000;
             box-shadow: 0 4px 8px rgba(0,0,0,0.4);
             display: flex;
             align-items: center;
             justify-content: center;
-            margin: 10px;
+            margin: 10px 0;
             transition: transform 0.2s;
             animation: pop 0.3s ease-out;
+            text-align: center;
         }
         .sign:hover {
             transform: scale(1.05) rotate(2deg);
@@ -75,10 +71,34 @@
             cursor: pointer;
             border-radius: 4px;
         }
+        #road {
+            position: relative;
+            width: 300px;
+            height: 100vh;
+            background: #555;
+            overflow: hidden;
+        }
+        #road::before {
+            content: '';
+            position: absolute;
+            left: 50%;
+            top: 0;
+            width: 10px;
+            height: 100%;
+            background: repeating-linear-gradient(to bottom, #fff 0, #fff 20px, transparent 20px, transparent 40px);
+            transform: translateX(-50%);
+            animation: dash 1s linear infinite;
+        }
+        @keyframes dash {
+            to { background-position: 0 40px; }
+        }
         #signs {
+            position: absolute;
+            top: 0;
+            left: -220px;
             display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
+            flex-direction: column;
+            align-items: flex-end;
         }
         #random-btn {
             margin-top: 10px;
@@ -88,13 +108,13 @@
 <body>
     <h1 style="font-size:64px; text-shadow:2px 2px 4px #000">Panneaux Fun</h1>
     <div id="create-form">
-        <input type="text" id="sign-text" placeholder="Écris ton panneau" maxlength="8">
-        <button id="create-btn">Créer</button>
+        <button id="create-btn">Créer un panneau</button>
         <button id="random-btn">Aléatoire</button>
     </div>
-    <div id="signs"></div>
+    <div id="road">
+        <div id="signs"></div>
+    </div>
     <script>
-        const signTextInput = document.getElementById('sign-text');
         const createBtn = document.getElementById('create-btn');
         const randomBtn = document.getElementById('random-btn');
         const signsContainer = document.getElementById('signs');
@@ -123,16 +143,8 @@
             });
         }
 
-        createBtn.addEventListener('click', async () => {
-            const text = signTextInput.value.trim();
-            if (!text) return;
-            await fetch('/signs', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({text})
-            });
-            signTextInput.value = '';
-            loadSigns();
+        createBtn.addEventListener('click', () => {
+            window.location.href = '/create.html';
         });
 
         randomBtn.addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- ajout d'une page `create.html` pour personnaliser un panneau
- mise à jour d'`index.html` pour afficher les panneaux au bord d'une route animée et rediriger vers la page de création

## Testing
- `npm install` *(échoue : accès au registre npm interdit)*
- `npm start` *(échoue : module `express` manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68497b057c40832d985628d12936c5a5